### PR TITLE
Add role-based access control middleware and navigation visibility

### DIFF
--- a/app/Http/Middleware/EnsureUserHasRole.php
+++ b/app/Http/Middleware/EnsureUserHasRole.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserHasRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  array<int, string>  $roles
+     */
+    public function handle(Request $request, Closure $next, string ...$roles): Response
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            return redirect()->route('login');
+        }
+
+        if (empty($roles) || in_array($user->tipo_usuario, $roles, true)) {
+            return $next($request);
+        }
+
+        abort(Response::HTTP_FORBIDDEN, 'Você não tem permissão para acessar esta página.');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\EnsureUserHasRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -103,14 +103,21 @@
                 </button>
 
                 <div class="collapse navbar-collapse" id="navbarNav">
+                    @php
+                        $usuarioAutenticado = Auth::user();
+                        $tipoUsuario = $usuarioAutenticado?->tipo_usuario;
+                    @endphp
+
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
-                        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+                        @if (in_array($tipoUsuario, ['admin', 'operador', 'motorista']))
                             <li class="nav-item">
                                 <a class="nav-link text-white" href="{{ route('pedidos.rastreamento') }}">
                                     <i class="bi bi-truck-front-fill me-1"></i> Rastreamento
                                 </a>
                             </li>
+                        @endif
 
+                        @if (in_array($tipoUsuario, ['admin', 'operador']))
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle text-white" href="#" id="operacionalDropdown"
                                     role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -121,7 +128,7 @@
                                             <i class="bi bi-signpost"></i> Criação de Rotas</a>
                                     </li>
                                     <li><a class="dropdown-item" href="{{ route('rotas.index') }}">
-                                            <i class="bi bi-map-fill"></i> Rotas </a>
+                                            <i class="bi bi-map-fill"></i> Rotas</a>
                                     </li>
                                     <li><a class="dropdown-item" href="{{ route('pedidos.index') }}"><i
                                                 class="bi bi-box"></i> Pedidos</a>
@@ -138,7 +145,8 @@
                                     <li>
                                         <a class="dropdown-item d-flex align-items-center gap-2"
                                             href="{{ route('centro.index') }}">
-                                            <i class="bi bi-truck fs-5 text-primary"></i> Centro de Distribuição
+                                            <i class="bi bi-building-fill-add fs-5 text-primary"></i> Centro de
+                                            Distribuição
                                         </a>
                                     </li>
 
@@ -155,30 +163,14 @@
                                             href="{{ route('modelo.index') }}">
                                             <i class="bi bi-gear fs-5 text-success"></i> Modelo do Veículo
                                         </a>
-                                    <li class="dropdown-divider"></li>
-                                    <li><a class="dropdown-item" href="{{ route('motorista.index') }}"><i
-                                                class="bi bi-person-badge"></i> Motorista</a></li>
-                                    <li><a class="dropdown-item" href="{{ route('read-user') }}"><i
-                                                class="bi bi-people"></i> Usuários</a></li>
-                                </ul>
-                                <ul class="dropdown-menu dropdown-menu-end dropdown-menu-dark">
-                                    <li>
-                                        <a class="dropdown-item d-flex align-items-center gap-2"
-                                            href="{{ route('veiculo.index') }}">
-                                            <i class="bi bi-truck fs-5 text-primary"></i> Veículo
-                                        </a>
                                     </li>
-                                    <li>
-                                        <a class="dropdown-item d-flex align-items-center gap-2"
-                                            href="{{ route('modelo.index') }}">
-                                            <i class="bi bi-gear fs-5 text-success"></i> Modelo do Veículo
-                                        </a>
                                     <li class="dropdown-divider"></li>
                                     <li><a class="dropdown-item" href="{{ route('motorista.index') }}"><i
                                                 class="bi bi-person-badge"></i> Motorista</a></li>
-                                    <li><a class="dropdown-item" href="{{ route('read-user') }}"><i
-                                                class="bi bi-people"></i> Usuários</a></li>
-
+                                    @if ($tipoUsuario === 'admin')
+                                        <li><a class="dropdown-item" href="{{ route('read-user') }}"><i
+                                                    class="bi bi-people"></i> Usuários</a></li>
+                                    @endif
                                 </ul>
                             </li>
 
@@ -195,17 +187,18 @@
                                         </a>
                                     </li>
                                     <li>
-                                        <a class="dropdown-item" href="#">
+                                        <a class="dropdown-item text-muted" href="#" aria-disabled="true">
                                             <i class="bi bi-person-circle me-2"></i> Perfil
                                         </a>
                                     </li>
                                     <li>
-                                        <a class="dropdown-item" href="#">
+                                        <a class="dropdown-item text-muted" href="#" aria-disabled="true">
                                             <i class="bi bi-sliders me-2"></i> Configurações
                                         </a>
                                     </li>
                                 </ul>
                             </li>
+
                             <li class="nav-item">
                                 <a class="nav-link text-white" href="{{ route('importacao.index') }}">
                                     <i class="bi bi-calculator me-1"></i> Importar XML
@@ -217,15 +210,14 @@
                                     <i class="bi bi-airplane-engines-fill me-1"></i> Painel
                                 </a>
                             </li>
+                        @endif
 
-                            <!-- Usuário / Logout -->
+                        @if ($usuarioAutenticado)
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle d-flex align-items-center gap-2" href="#"
                                     role="button" data-bs-toggle="dropdown" style="color: #fff;">
-
-                                    <!-- Foto do usuário -->
-                                    @if (Auth::user()->foto)
-                                        <img src="{{ asset('usuarios/' . Auth::user()->foto) }}"
+                                    @if ($usuarioAutenticado->foto)
+                                        <img src="{{ asset('usuarios/' . $usuarioAutenticado->foto) }}"
                                             alt="Foto do usuário" class="rounded-circle border border-warning"
                                             style="width: 36px; height: 36px; object-fit: cover;">
                                     @else
@@ -236,8 +228,8 @@
                                 <ul class="dropdown-menu dropdown-menu-end dropdown-menu-dark">
                                     <li>
                                         <a class="dropdown-item"
-                                            href="{{ route('show.user', ['id' => Auth::user()->id_usuario]) }}">
-                                            <i class="bi bi-box-arrow-right me-2"></i> Ver usuário
+                                            href="{{ route('show.user', ['id' => $usuarioAutenticado->id_usuario]) }}">
+                                            <i class="bi bi-person-lines-fill me-2"></i> Ver usuário
                                         </a>
                                         <a class="dropdown-item" href="#"
                                             onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
@@ -251,10 +243,10 @@
                                     @csrf
                                 </form>
                             </li>
-                        </ul>
-
-                        @yield('menu')
+                        @endif
                     </ul>
+
+                    @yield('menu')
                 </div>
             </div>
         </nav>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,80 +34,73 @@ Route::middleware(['auth'])->group(function () {
         return view('home.dashboard');
     })->name('dashboard');
 
-    /*Route::prefix('user')->name('user.')->group(function() {
-
-    });*/
-
-
-    Route::get('/user-read', [UsuarioController::class, 'read'])->name('read-user');
-
-    Route::post('/user-store', [UsuarioController::class, 'store'])->name('store-user');
-
-    Route::delete('/user-destroy/{user}', [UsuarioController::class, 'destroy'])->name('destroy-user');
-
-    Route::put('user-update/{usuario}', [UsuarioController::class, 'update'])->name('update-user');
-
-    Route::get('/user/show/{id}', [UsuarioController::class, 'show'])->name('show.user');
-
-    Route::get('/user/senha/{id}', [UsuarioController::class, 'senha'])->name('senha.user');
-
-    Route::put('user/updatePassword/{id}', [UsuarioController::class, 'updatePassword'])->name('updatePassword.user');
-
-    Route::get('/user/procurar', [UsuarioController::class, 'procurar'])->name('usuarios.procurar');
-
-    Route::post('/user/inserir{id}', [UsuarioController::class, 'inserirFoto'])->name('usuarios.inserir');
-
-    Route::prefix('motorista')->name('motorista.')->group(function () {
-        Route::get('/', [MotoristaController::class, 'index'])->name('index');
-        Route::post('/store', [MotoristaController::class, 'store'])->name('store');
-        Route::post('/show/{id}', [MotoristaController::class, 'show'])->name('show');
-        Route::put('/update/{id}', [MotoristaController::class, 'update'])->name('update');
+    Route::middleware('role:admin')->group(function () {
+        Route::get('/user-read', [UsuarioController::class, 'read'])->name('read-user');
+        Route::post('/user-store', [UsuarioController::class, 'store'])->name('store-user');
+        Route::delete('/user-destroy/{user}', [UsuarioController::class, 'destroy'])->name('destroy-user');
+        Route::put('user-update/{usuario}', [UsuarioController::class, 'update'])->name('update-user');
+        Route::get('/user/show/{id}', [UsuarioController::class, 'show'])->name('show.user');
+        Route::get('/user/senha/{id}', [UsuarioController::class, 'senha'])->name('senha.user');
+        Route::put('user/updatePassword/{id}', [UsuarioController::class, 'updatePassword'])->name('updatePassword.user');
+        Route::get('/user/procurar', [UsuarioController::class, 'procurar'])->name('usuarios.procurar');
+        Route::post('/user/inserir{id}', [UsuarioController::class, 'inserirFoto'])->name('usuarios.inserir');
     });
 
-    Route::prefix('modelo')->name('modelo.')->group(function () {
-        Route::get('/', [ModeloController::class, 'index'])->name('index');
-        Route::post('/store', [ModeloController::class, 'store'])->name('store');
+    Route::middleware('role:admin,operador')->group(function () {
+        Route::prefix('motorista')->name('motorista.')->group(function () {
+            Route::get('/', [MotoristaController::class, 'index'])->name('index');
+            Route::post('/store', [MotoristaController::class, 'store'])->name('store');
+            Route::post('/show/{id}', [MotoristaController::class, 'show'])->name('show');
+            Route::put('/update/{id}', [MotoristaController::class, 'update'])->name('update');
+        });
+
+        Route::prefix('modelo')->name('modelo.')->group(function () {
+            Route::get('/', [ModeloController::class, 'index'])->name('index');
+            Route::post('/store', [ModeloController::class, 'store'])->name('store');
+        });
+
+        Route::prefix('veiculo')->name('veiculo.')->group(function () {
+            Route::get('/', [VeiculoController::class, 'index'])->name('index');
+            Route::post('/store', [VeiculoController::class, 'store'])->name('store');
+        });
+
+        Route::prefix('centro')->name('centro.')->group(function () {
+            Route::get('/', [CentroController::class, 'index'])->name('index');
+            Route::post('/store', [CentroController::class, 'store'])->name('store');
+        });
+
+        Route::prefix('importacao')->name('importacao.')->group(function () {
+            Route::get('/', [ImportacaoController::class, 'index'])->name('index');
+            Route::post('/store',  [ImportacaoController::class, 'store'])->name('store');
+        });
+
+        Route::prefix('pedidos')->name('pedidos.')->group(function () {
+            Route::get('/', [PedidoController::class, 'index'])->name('index');
+            Route::post('/show', [PedidoController::class, 'show'])->name('show');
+            Route::get('/editar/{id}', [PedidoController::class, 'edit'])->name('edit');
+            Route::put('/editando/{id}', [PedidoController::class, 'update'])->name('update');
+            Route::get('/painel', [PedidoController::class, 'painel'])->name('painel');
+            Route::get('/foto', [PedidoController::class, 'foto'])->name('foto');
+        });
+
+        Route::get('/pedidos/exportar', [PedidoController::class, 'exportarExcel'])->name('pedidos.exportar');
+
+        Route::prefix('endereco')->name('endereco.')->group(function () {
+            Route::get('/', [EnderecoController::class, 'index'])->name('index');
+            Route::put('/{id_endereco}', [EnderecoController::class, 'update'])->name('update');
+        });
+
+        Route::prefix('rotas')->name('rotas.')->group(function () {
+            Route::get('/', [RotaController::class, 'index'])->name('index');
+            Route::get('/criacao', [RotaController::class, 'create'])->name('create');
+            Route::post('/store', [RotaController::class, 'store'])->name('store');
+            Route::post('/entrega', [RotaController::class, 'store_entrega'])->name('entrega.store');
+            Route::get('/show/{rotas}', [RotaController::class, 'show'])->name('show');
+            Route::post('/historico', [RotaController::class, 'historico'])->name('historico');
+        });
     });
 
-    Route::prefix('veiculo')->name('veiculo.')->group(function () {
-        Route::get('/', [VeiculoController::class, 'index'])->name('index');
-        Route::post('/store', [VeiculoController::class, 'store'])->name('store');
-    });
-
-    Route::prefix('centro')->name('centro.')->group(function () {
-        Route::get('/', [CentroController::class, 'index'])->name('index');
-        Route::post('/store', [CentroController::class, 'store'])->name('store');
-    });
-
-    Route::prefix('importacao')->name('importacao.')->group(function () {
-        Route::get('/', [ImportacaoController::class, 'index'])->name('index');
-        Route::post('/store',  [ImportacaoController::class, 'store'])->name('store');
-    });
-
-    Route::prefix('pedidos')->name('pedidos.')->group(function () {
-        Route::get('/', [PedidoController::class, 'index'])->name('index');
-        Route::get('/rastreamento', [PedidoController::class, 'rastreamento'])->name('rastreamento');
-        Route::post('/show', [PedidoController::class, 'show'])->name('show');
-        Route::get('/editar/{id}', [PedidoController::class, 'edit'])->name('edit');
-        Route::put('/editando/{id}', [PedidoController::class, 'update'])->name('update');
-        Route::get('/painel', [PedidoController::class, 'painel'])->name('painel');
-        Route::get('/foto', [PedidoController::class, 'foto'])->name('foto');
-    });
-
-    Route::get('/pedidos/exportar', [PedidoController::class, 'exportarExcel'])->name('pedidos.exportar');
-
-
-    Route::prefix('endereco')->name('endereco.')->group(function () {
-        Route::get('/', [EnderecoController::class, 'index'])->name('index');
-        Route::put('/{id_endereco}', [EnderecoController::class, 'update'])->name('update');
-    });
-
-    Route::prefix('rotas')->name('rotas.')->group(function () {
-        Route::get('/', [RotaController::class, 'index'])->name('index');
-        Route::get('/criacao', [RotaController::class, 'create'])->name('create');
-        Route::post('/store', [RotaController::class, 'store'])->name('store');
-        Route::post('/entrega', [RotaController::class, 'store_entrega'])->name('entrega.store');
-        Route::get('/show/{rotas}', [RotaController::class, 'show'])->name('show');
-        Route::post('/historico', [RotaController::class, 'historico'])->name('historico');
-    });
+    Route::get('/pedidos/rastreamento', [PedidoController::class, 'rastreamento'])
+        ->middleware('role:admin,operador,motorista')
+        ->name('pedidos.rastreamento');
 });


### PR DESCRIPTION
## Summary
- create a reusable middleware to check the authenticated user role
- register the middleware alias and protect the appropriate route groups
- hide navigation menu items that the signed-in user is not allowed to access

## Testing
- php artisan test *(fails: vendor/autoload.php not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec7472bee48325a65d121930d80aaf